### PR TITLE
Fix listenip to be inline with proxy.pp

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -213,7 +213,7 @@ class zabbix::agent (
   # to network name. If more than 1 interfaces are available, we
   # can find the ipaddress of this specific interface if listenip
   # is set to for example "eth1" or "bond0.73".
-  if $listenip == undefined {
+  if ($listenip == defined) {
     if ($listenip =~ /^(eth|bond|lxc).*/) {
       $int_name = "ipaddress_${listenip}"
       $listen_ip = inline_template('<%= scope.lookupvar(int_name) %>')


### PR DESCRIPTION
proxy.pp uses if ($listenip == defined) and agent uses if $listenip == undefined there by skipping the test when the parameter is set which is not what is meant to happen. Alternative is to change both proxy.pp and agent.pp to use if $listenip != undefined but thats two changes
